### PR TITLE
Sitemap disable

### DIFF
--- a/sb/config/commonConfig.go
+++ b/sb/config/commonConfig.go
@@ -215,6 +215,8 @@ type SitemapConfig struct {
 	Priority float64
 	// The sitemap filename.
 	Filename string
+	// Whether to disable page inclusion.
+	Disable bool
 }
 
 func DecodeSitemap(prototype SitemapConfig, input map[string]any) (SitemapConfig, error) {

--- a/sb/hugolib/config_test.go
+++ b/sb/hugolib/config_test.go
@@ -490,11 +490,10 @@ name = "menu-theme"
 			got := b.Configs.Base
 
 			if mergeStrategy == "none" {
-				b.Assert(got.Sitemap, qt.DeepEquals, config.SitemapConfig{ChangeFreq: "", Priority: -1, Filename: "sitemap.xml"})
-
+				b.Assert(got.Sitemap, qt.DeepEquals, config.SitemapConfig{ChangeFreq: "", Disable: false, Priority: -1, Filename: "sitemap.xml"})
 				b.AssertFileContent("public/sitemap.xml", "schemas/sitemap")
 			} else {
-				b.Assert(got.Sitemap, qt.DeepEquals, config.SitemapConfig{ChangeFreq: "monthly", Priority: -1, Filename: "sitemap.xml"})
+				b.Assert(got.Sitemap, qt.DeepEquals, config.SitemapConfig{ChangeFreq: "monthly", Disable: false, Priority: -1, Filename: "sitemap.xml"})
 				b.AssertFileContent("public/sitemap.xml", "<changefreq>monthly</changefreq>")
 			}
 		})

--- a/sb/hugolib/sitemap_test.go
+++ b/sb/hugolib/sitemap_test.go
@@ -108,11 +108,12 @@ outputs: [ "html", "amp" ]
 
 func TestParseSitemap(t *testing.T) {
 	t.Parallel()
-	expected := config.SitemapConfig{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3"}
+	expected := config.SitemapConfig{ChangeFreq: "3", Disable: true, Filename: "doo.xml", Priority: 3.0}
 	input := map[string]any{
 		"changefreq": "3",
-		"priority":   3.0,
+		"disable":    true,
 		"filename":   "doo.xml",
+		"priority":   3.0,
 		"unknown":    "ignore",
 	}
 	result, err := config.DecodeSitemap(config.SitemapConfig{}, input)

--- a/sb/tpl/tplimpl/embedded/templates/_default/sitemap.xml
+++ b/sb/tpl/tplimpl/embedded/templates/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages "Sitemap.Disable" "ne" true }}
     {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
Allows an individual page to be opted out of the sitemap.

This PR is originally from upstream: https://github.com/gohugoio/hugo/pull/12329

Funny enough, if you look through the upstream PR, it originates from a PR I made in 2018 to Hugo. After a lot of back and forth and a small tweak, they finally merged it upstream 2 days ago.