### PR TITLE
Set Goldmark html render to true

### DIFF
--- a/sb/markup/goldmark/goldmark_config/config.go
+++ b/sb/markup/goldmark/goldmark_config/config.go
@@ -58,7 +58,7 @@ var Default = Config{
 		},
 	},
 	Renderer: Renderer{
-		Unsafe: false,
+		Unsafe: true,
 	},
 	Parser: Parser{
 		AutoHeadingID:                      true,


### PR DESCRIPTION
The Goldmark.Renderer.Unsafe was updated to be true by default. This allows for the use of HTML in the markdown files.

This value could be disabled by passing the below:

```yaml
markup:
  goldmark:
    renderer:
      unsafe = true
```